### PR TITLE
Add support for Tomcat 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ _Note: Currently Java, NODE, .NET, PHP and Python are supported._
 ##### Node, .NET, PHP or Python
 Add the following to the startup command box
 
-      curl -s https://raw.githubusercontent.com/DataDog/datadog-aas-linux/v1.2.0/datadog_wrapper | bash
+      curl -s https://raw.githubusercontent.com/DataDog/datadog-aas-linux/v1.3.0/datadog_wrapper | bash
 
 ![](https://p-qkfgo2.t2.n0.cdn.getcloudapp.com/items/8LuqpR7e/6a9bf63d-5169-49d0-a68a-20e6e3009d47.jpg?v=7704a16bc91a6a57caf8befd84204415)
 

--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -14,6 +14,9 @@ main() {
     echo "Creating and switching to the Datadog directory at $DD_DIR"
     mkdir -p "$DD_DIR" && cd "$DD_DIR" || return
 
+    echo "Adding Runtime specific dependencies"
+    getRuntimeDependencies
+
     echo "Getting the Datadog binaries"
     getBinaries
 
@@ -75,11 +78,22 @@ setEnvVars() {
 
 }
 
-getBinaries() {
-    if [ "$WEBSITE_STACK" == "PHP" ] || [ "$WEBSITE_STACK" == "JAVA" ] || [ "$WEBSITE_STACK" == "TOMCAT" ]; then
+getRuntimeDependencies() {
+    if [ "$WEBSITE_STACK" == "TOMCAT" ]; then
+        DD_TOMCAT_VERSION=$(echo "$TOMCAT_VERSION" | awk -F. '{print $1}')
+    fi
+
+    if [ "$WEBSITE_STACK" == "PHP" ] || [ "$WEBSITE_STACK" == "JAVA" ] || [ "$DD_TOMCAT_VERSION" == "10" ]; then
         apt-get update && apt-get install -y unzip
     fi
 
+    if [ "$DD_TOMCAT_VERSION" == "9" ]; then
+        apk add curl
+        apk add libc6-compat
+    fi
+}
+
+getBinaries() {
     #Check if we have already installed this version
     if [ ! -d "$DD_BINARY_DIR" ]; then
 

--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -57,7 +57,7 @@ setEnvVars() {
     fi
 
     if [ -z "$DD_AAS_LINUX_VERSION" ]; then
-        DD_AAS_LINUX_VERSION="v1.2.0"
+        DD_AAS_LINUX_VERSION="v1.3.0"
     fi
 
     if [ -z "$DD_BINARY_DIR" ]; then


### PR DESCRIPTION
The previous version only supported Tomcat 10. Tomcat 9 is on an Alpine image and required some additional steps.

- Adds logic to recognize Tomcat 9 and add dependencies for the wrapper
- Updates the version in the readme and wrapper for the next release

Tested in multiple Tomcat applications.