### PR TITLE
Add Support for Java 8 and 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ _Note: Currently Java, NODE, .NET, PHP and Python are supported._
 ##### Node, .NET, PHP or Python
 Add the following to the startup command box
 
-      curl -s https://raw.githubusercontent.com/DataDog/datadog-aas-linux/v1.4.0/datadog_wrapper | bash
+      curl -s https://raw.githubusercontent.com/DataDog/datadog-aas-linux/v1.3.0/datadog_wrapper | bash
 
 ![](https://p-qkfgo2.t2.n0.cdn.getcloudapp.com/items/8LuqpR7e/6a9bf63d-5169-49d0-a68a-20e6e3009d47.jpg?v=7704a16bc91a6a57caf8befd84204415)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ _Note: Currently Java, NODE, .NET, PHP and Python are supported._
 ##### Node, .NET, PHP or Python
 Add the following to the startup command box
 
-      curl -s https://raw.githubusercontent.com/DataDog/datadog-aas-linux/v1.3.0/datadog_wrapper | bash
+      curl -s https://raw.githubusercontent.com/DataDog/datadog-aas-linux/v1.4.0/datadog_wrapper | bash
 
 ![](https://p-qkfgo2.t2.n0.cdn.getcloudapp.com/items/8LuqpR7e/6a9bf63d-5169-49d0-a68a-20e6e3009d47.jpg?v=7704a16bc91a6a57caf8befd84204415)
 

--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -69,7 +69,7 @@ setEnvVars() {
     fi
 
     if [ -z "$DD_CUSTOM_METRICS_ENABLED" ]; then
-        DD_CUSTOM_METRICS_ENABLED="false"
+        DD_CUSTOM_METRICS_ENABLED="false"There
     fi
 
     if [ -z "$DD_LOG_LEVEL" ]; then
@@ -79,15 +79,22 @@ setEnvVars() {
 }
 
 getRuntimeDependencies() {
+    # There are multiple base images used for runtimes. We need to ensure all required dependencies are available.
+    if [ "$WEBSITE_STACK" == "JAVA" ]; then
+        DD_JAVA_VERSION=$(java -fullversion 2>&1 | awk -F'[".]' '{print $2}')
+    fi
+
     if [ "$WEBSITE_STACK" == "TOMCAT" ]; then
         DD_TOMCAT_VERSION=$(echo "$TOMCAT_VERSION" | awk -F. '{print $1}')
     fi
 
-    if [ "$WEBSITE_STACK" == "PHP" ] || [ "$WEBSITE_STACK" == "JAVA" ] || [ "$DD_TOMCAT_VERSION" == "10" ]; then
+
+    if [ "$WEBSITE_STACK" == "PHP" ] || [ "$DD_JAVA_VERSION" == "17" ] || [ "$DD_TOMCAT_VERSION" == "10" ]; then
         apt-get update && apt-get install -y unzip
     fi
 
-    if [ "$DD_TOMCAT_VERSION" == "9" ]; then
+    # output is openjdk full version "1.8.0_345-b01" for java 8 and openjdk full version "17.0.7+7-LTS" for 17
+    if [ "$DD_JAVA_VERSION" == "1" ] || [ "$DD_JAVA_VERSION" == "11" ] ||[ "$DD_TOMCAT_VERSION" == "9" ]; then
         apk add curl
         apk add libc6-compat
     fi

--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -57,7 +57,7 @@ setEnvVars() {
     fi
 
     if [ -z "$DD_AAS_LINUX_VERSION" ]; then
-        DD_AAS_LINUX_VERSION="v1.4.0"
+        DD_AAS_LINUX_VERSION="v1.3.0"
     fi
 
     if [ -z "$DD_BINARY_DIR" ]; then

--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -153,7 +153,7 @@ setUpNodeEnv() {
 setUpDotnetEnv() {
     echo "Setting up Datadog tracing for .NET"
     if [ -z "$DD_DOTNET_TRACER_VERSION" ]; then
-        DD_DOTNET_TRACER_VERSION=2.19.0
+        DD_DOTNET_TRACER_VERSION=2.36.0
     fi
     DD_DOTNET_TRACER_FILE=datadog-dotnet-apm-${DD_DOTNET_TRACER_VERSION}.tar.gz
     DD_DOTNET_TRACER_URL=https://github.com/DataDog/dd-trace-dotnet/releases/download/v${DD_DOTNET_TRACER_VERSION}/${DD_DOTNET_TRACER_FILE}
@@ -175,7 +175,7 @@ setUpDotnetEnv() {
 setUpJavaEnv() {
     echo "Setting up Datadog tracing for Java"
     if [ -z "$DD_JAVA_TRACER_VERSION" ]; then
-        DD_JAVA_TRACER_VERSION=1.4.0
+        DD_JAVA_TRACER_VERSION=1.19.3
     fi
 
     echo "Using version $DD_JAVA_TRACER_VERSION of the JAVA tracer"
@@ -201,7 +201,7 @@ setUpJavaEnv() {
 setupPHPEnv() {
     echo "Setting up Datadog tracing for PHP"
     if [ -z "$DD_PHP_TRACER_VERSION" ]; then
-        DD_PHP_TRACER_VERSION=0.83.1
+        DD_PHP_TRACER_VERSION=0.90.0
     fi
 
     DD_PHP_TRACER_URL=https://github.com/DataDog/dd-trace-php/releases/download/${DD_PHP_TRACER_VERSION}/datadog-setup.php
@@ -218,7 +218,7 @@ setupPHPEnv() {
 setUpPyEnv() {
     echo "Setting up Datadog tracing for Python"
     if [ -z "$DD_PYTHON_TRACER_VERSION" ]; then
-        DD_PYTHON_TRACER_VERSION=1.7.0
+        DD_PYTHON_TRACER_VERSION=1.18.2
     fi
 
     pip install ddtrace

--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -57,7 +57,7 @@ setEnvVars() {
     fi
 
     if [ -z "$DD_AAS_LINUX_VERSION" ]; then
-        DD_AAS_LINUX_VERSION="v1.3.0"
+        DD_AAS_LINUX_VERSION="v1.4.0"
     fi
 
     if [ -z "$DD_BINARY_DIR" ]; then

--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -69,7 +69,7 @@ setEnvVars() {
     fi
 
     if [ -z "$DD_CUSTOM_METRICS_ENABLED" ]; then
-        DD_CUSTOM_METRICS_ENABLED="false"There
+        DD_CUSTOM_METRICS_ENABLED="false"
     fi
 
     if [ -z "$DD_LOG_LEVEL" ]; then

--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -5,19 +5,19 @@ main() {
     export DD_AZURE_APP_SERVICES=1
     export DD_HOSTNAME="none"
 
-    if [ -z "${DD_CHDIR}" ]; then 
+    if [ -z "${DD_CHDIR}" ]; then
         CURRENT_DIR=$(pwd)
-    else 
-        CURRENT_DIR="$(pwd)/$DD_CHDIR"
+    else
+        CURRENT_DIR="$(pwd)/${DD_CHDIR}"
     fi
 
-    echo "Set application directory as $CURRENT_DIR"
+    echo "Set application directory as ${CURRENT_DIR}"
 
     echo "Setting Datadog environment variables"
     setEnvVars
 
-    echo "Creating and switching to the Datadog directory at $DD_DIR"
-    mkdir -p "$DD_DIR" && cd "$DD_DIR" || return
+    echo "Creating and switching to the Datadog directory at ${DD_DIR}"
+    mkdir -p "${DD_DIR}" && cd "${DD_DIR}" || return
 
     echo "Adding Runtime specific dependencies"
     getRuntimeDependencies
@@ -47,37 +47,37 @@ main() {
     esac
 
     echo "Removing any previous installations"
-    find "$DD_DIR"/v* -type d | grep -v "$DD_BINARY_DIR" | xargs -r rm -r
+    find "${DD_DIR}"/v* -type d | grep -v "${DD_BINARY_DIR}" | xargs -r rm -r
 
     echo "Completed Datadog setup"
 }
 
 setEnvVars() {
-    if [ -z "$DD_DIR" ]; then
+    if [ -z "${DD_DIR}" ]; then
         DD_DIR="/home/datadog"
     fi
 
-    if [ -z "$DD_BINARIES_URL" ]; then
+    if [ -z "${DD_BINARIES_URL}" ]; then
         DD_BINARIES_URL="https://github.com/DataDog/datadog-aas-linux/releases/download"
     fi
 
-    if [ -z "$DD_AAS_LINUX_VERSION" ]; then
+    if [ -z "${DD_AAS_LINUX_VERSION}" ]; then
         DD_AAS_LINUX_VERSION="v1.4.0"
     fi
 
-    if [ -z "$DD_BINARY_DIR" ]; then
+    if [ -z "${DD_BINARY_DIR}" ]; then
         DD_BINARY_DIR="${DD_DIR}/${DD_AAS_LINUX_VERSION}"
     fi
 
-    if [ -z "$DD_TRACE_ENABLED" ]; then
+    if [ -z "${DD_TRACE_ENABLED}" ]; then
         DD_TRACE_ENABLED="true"
     fi
 
-    if [ -z "$DD_CUSTOM_METRICS_ENABLED" ]; then
+    if [ -z "${DD_CUSTOM_METRICS_ENABLED}" ]; then
         DD_CUSTOM_METRICS_ENABLED="false"
     fi
 
-    if [ -z "$DD_LOG_LEVEL" ]; then
+    if [ -z "${DD_LOG_LEVEL}" ]; then
         DD_LOG_LEVEL="error"
     fi
 
@@ -85,21 +85,21 @@ setEnvVars() {
 
 getRuntimeDependencies() {
     # There are multiple base images used for runtimes. We need to ensure all required dependencies are available.
-    if [ "$WEBSITE_STACK" == "JAVA" ]; then
+    if [ "${WEBSITE_STACK}" == "JAVA" ]; then
         DD_JAVA_VERSION=$(java -fullversion 2>&1 | awk -F'[".]' '{print $2}')
     fi
 
-    if [ "$WEBSITE_STACK" == "TOMCAT" ]; then
-        DD_TOMCAT_VERSION=$(echo "$TOMCAT_VERSION" | awk -F. '{print $1}')
+    if [ "${WEBSITE_STACK}" == "TOMCAT" ]; then
+        DD_TOMCAT_VERSION=$(echo "${TOMCAT_VERSION}" | awk -F. '{print $1}')
     fi
 
 
-    if [ "$WEBSITE_STACK" == "PHP" ] || [ "$DD_JAVA_VERSION" == "17" ] || [ "$DD_TOMCAT_VERSION" == "10" ]; then
+    if [ "${WEBSITE_STACK}" == "PHP" ] || [ "${DD_JAVA_VERSION}" == "17" ] || [ "${DD_TOMCAT_VERSION}" == "10" ]; then
         apt-get update && apt-get install -y unzip
     fi
 
     # output is openjdk full version "1.8.0_345-b01" for java 8 and openjdk full version "17.0.7+7-LTS" for 17
-    if [ "$DD_JAVA_VERSION" == "1" ] || [ "$DD_JAVA_VERSION" == "11" ] ||[ "$DD_TOMCAT_VERSION" == "9" ]; then
+    if [ "${DD_JAVA_VERSION}" == "1" ] || [ "${DD_JAVA_VERSION}" == "11" ] ||[ "${DD_TOMCAT_VERSION}" == "9" ]; then
         apk add curl
         apk add libc6-compat
     fi
@@ -107,16 +107,16 @@ getRuntimeDependencies() {
 
 getBinaries() {
     #Check if we have already installed this version
-    if [ ! -d "$DD_BINARY_DIR" ]; then
+    if [ ! -d "${DD_BINARY_DIR}" ]; then
 
         FILE="datadog-aas-${DD_AAS_LINUX_VERSION}.zip"
 
-        echo "Downloading Datadog AAS binary $DD_BINARIES_URL/$DD_AAS_LINUX_VERSION/$FILE"
-        if curl -L --fail "$DD_BINARIES_URL/$DD_AAS_LINUX_VERSION/$FILE" -o "$FILE"; then
+        echo "Downloading Datadog AAS binary ${DD_BINARIES_URL}/${DD_AAS_LINUX_VERSION}/${FILE}"
+        if curl -L --fail "${DD_BINARIES_URL}/${DD_AAS_LINUX_VERSION}/${FILE}" -o "${FILE}"; then
             echo "Unzipping files"
-            unzip "$FILE" || return
+            unzip "${FILE}" || return
             echo "Removing zip file"
-            rm "$FILE"
+            rm "${FILE}"
 
         else
             echo "Failed to download the Datadog binary succesfully."
@@ -124,7 +124,7 @@ getBinaries() {
         fi
 
     else
-        echo "Version $DD_AAS_LINUX_VERSION of Datadog AAS previously installed"
+        echo "Version ${DD_AAS_LINUX_VERSION} of Datadog AAS previously installed"
     fi
 }
 
@@ -132,14 +132,14 @@ startBinaries() {
 
     BINARY_DIR="${DD_DIR}/${DD_AAS_LINUX_VERSION}"
 
-    if [ "$DD_TRACE_ENABLED" = "true" ]; then
+    if [ "${DD_TRACE_ENABLED}" = "true" ]; then
         echo "Starting the trace agent"
-        eval "$DD_BINARY_DIR/process_manager $BINARY_DIR/trace-agent &"
+        eval "${DD_BINARY_DIR}/process_manager ${BINARY_DIR}/trace-agent &"
     fi
 
     if [ "$DD_CUSTOM_METRICS_ENABLED" = "true" ]; then
         echo "Starting DogStatsD"
-        eval "$DD_BINARY_DIR/process_manager $BINARY_DIR/dogstatsd start &"
+        eval "${DD_BINARY_DIR}/process_manager ${BINARY_DIR}/dogstatsd start &"
     fi
 }
 
@@ -149,23 +149,23 @@ setUpNodeEnv() {
     yarn add dd-trace || return
 
     ORIG_NODE_OPTIONS=$NODE_OPTIONS
-    export NODE_OPTIONS="--require=$DD_DIR/node_modules/dd-trace/init $ORIG_NODE_OPTIONS"
+    export NODE_OPTIONS="--require=${DD_DIR}/node_modules/dd-trace/init ${ORIG_NODE_OPTIONS}"
 
     # confirm updates to NODE_OPTIONS
-    node --help >/dev/null || (export NODE_OPTIONS="$ORIG_NODE_OPTIONS" && return)
+    node --help >/dev/null || (export NODE_OPTIONS="${ORIG_NODE_OPTIONS}" && return)
 }
 
 setUpDotnetEnv() {
     echo "Setting up Datadog tracing for .NET"
-    if [ -z "$DD_DOTNET_TRACER_VERSION" ]; then
+    if [ -z "${DD_DOTNET_TRACER_VERSION}" ]; then
         DD_DOTNET_TRACER_VERSION=2.36.0
     fi
     DD_DOTNET_TRACER_FILE=datadog-dotnet-apm-${DD_DOTNET_TRACER_VERSION}.tar.gz
     DD_DOTNET_TRACER_URL=https://github.com/DataDog/dd-trace-dotnet/releases/download/v${DD_DOTNET_TRACER_VERSION}/${DD_DOTNET_TRACER_FILE}
 
-    echo "Installing .NET tracer from $DD_DOTNET_TRACER_URL"
-    if curl -L --fail "$DD_DOTNET_TRACER_URL" -o "$DD_DOTNET_TRACER_FILE"; then
-        tar -xzf "$DD_DOTNET_TRACER_FILE" || return
+    echo "Installing .NET tracer from ${DD_DOTNET_TRACER_URL}"
+    if curl -L --fail "${DD_DOTNET_TRACER_URL}" -o "${DD_DOTNET_TRACER_FILE}"; then
+        tar -xzf "${DD_DOTNET_TRACER_FILE}" || return
     else
         echo "Downloading the tracer was unsuccessful"
         return
@@ -179,25 +179,25 @@ setUpDotnetEnv() {
 
 setUpJavaEnv() {
     echo "Setting up Datadog tracing for Java"
-    if [ -z "$DD_JAVA_TRACER_VERSION" ]; then
+    if [ -z "${DD_JAVA_TRACER_VERSION}" ]; then
         DD_JAVA_TRACER_VERSION=1.19.3
     fi
 
-    echo "Using version $DD_JAVA_TRACER_VERSION of the JAVA tracer"
-    DD_JAVA_TRACER_FILE="dd-java-agent-$DD_JAVA_TRACER_VERSION.jar"
-    DD_JAVA_TRACER_URL="https://github.com/DataDog/dd-trace-java/releases/download/v$DD_JAVA_TRACER_VERSION/$DD_JAVA_TRACER_FILE"
+    echo "Using version ${DD_JAVA_TRACER_VERSION} of the JAVA tracer"
+    DD_JAVA_TRACER_FILE="dd-java-agent-${DD_JAVA_TRACER_VERSION}.jar"
+    DD_JAVA_TRACER_URL="https://github.com/DataDog/dd-trace-java/releases/download/v${DD_JAVA_TRACER_VERSION}/${DD_JAVA_TRACER_FILE}"
 
-    echo "Installing JAVA tracer from $DD_JAVA_TRACER_URL"
-    if ! curl -L --fail "$DD_JAVA_TRACER_URL" -o "$DD_JAVA_TRACER_FILE"; then
+    echo "Installing JAVA tracer from ${DD_JAVA_TRACER_URL}"
+    if ! curl -L --fail "${DD_JAVA_TRACER_URL}" -o "${DD_JAVA_TRACER_FILE}"; then
         echo "Downloading the tracer was unsuccessful"
         return
     fi
 
     echo "Adding the JAVA tracer to the startup command"
-    DD_JAVAAGENT="-javaagent:$DD_DIR/$DD_JAVA_TRACER_FILE"
+    DD_JAVAAGENT="-javaagent:${DD_DIR}/${DD_JAVA_TRACER_FILE}"
 
-    if [ "$WEBSITE_STACK" == "TOMCAT" ]; then
-        export JAVA_OPTS="$JAVA_OPTS $DD_JAVAAGENT"
+    if [ "${WEBSITE_STACK}" == "TOMCAT" ]; then
+        export JAVA_OPTS="${JAVA_OPTS} ${DD_JAVAAGENT}"
     else
         DD_START_APP=$(echo "${DD_START_APP//-jar/$DD_JAVAAGENT -jar}")
     fi
@@ -205,14 +205,14 @@ setUpJavaEnv() {
 
 setupPHPEnv() {
     echo "Setting up Datadog tracing for PHP"
-    if [ -z "$DD_PHP_TRACER_VERSION" ]; then
+    if [ -z "${DD_PHP_TRACER_VERSION}" ]; then
         DD_PHP_TRACER_VERSION=0.90.0
     fi
 
     DD_PHP_TRACER_URL=https://github.com/DataDog/dd-trace-php/releases/download/${DD_PHP_TRACER_VERSION}/datadog-setup.php
 
-    echo "Installing PHP tracer from $DD_PHP_TRACER_URL"
-    if curl -LO --fail "$DD_PHP_TRACER_URL"; then
+    echo "Installing PHP tracer from ${DD_PHP_TRACER_URL}"
+    if curl -LO --fail "${DD_PHP_TRACER_URL}"; then
         eval "php datadog-setup.php --php-bin=all"
     else
         echo "Downloading the tracer was unsuccessful"
@@ -222,7 +222,7 @@ setupPHPEnv() {
 
 setUpPyEnv() {
     echo "Setting up Datadog tracing for Python"
-    if [ -z "$DD_PYTHON_TRACER_VERSION" ]; then
+    if [ -z "${DD_PYTHON_TRACER_VERSION}" ]; then
         DD_PYTHON_TRACER_VERSION=1.18.2
     fi
 
@@ -232,6 +232,6 @@ setUpPyEnv() {
 }
 
 main
-echo "Executing start command: \"$DD_START_APP\""
-cd "$CURRENT_DIR"
-eval "$DD_START_APP"
+echo "Executing start command: \"${DD_START_APP}\""
+cd "${CURRENT_DIR}"
+eval "${DD_START_APP}"


### PR DESCRIPTION
This PR updates the wrapper to correctly instrument applications in Java 8 and Java 11. These runtimes are using Alpine images and were not being instrumented properly.

Also
- bumps the version to v1.4.0
- updates syntax for variables to use {}