### PR TITLE
Add optional $DD_CHDIR to run code in different directory

### DIFF
--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -5,7 +5,12 @@ main() {
     export DD_AZURE_APP_SERVICES=1
     export DD_HOSTNAME="none"
 
-    CURRENT_DIR=$(pwd)
+    if [ -z "${DD_CHDIR}" ]; then 
+        CURRENT_DIR=$(pwd)
+    else 
+        CURRENT_DIR="$(pwd)/$DD_CHDIR"
+    fi
+
     echo "Set application directory as $CURRENT_DIR"
 
     echo "Setting Datadog environment variables"


### PR DESCRIPTION
Add support for cd'ing into a sub directory before executing code.

Works around to DD_START_APP in coordination with dd-trace not supporting using "cd" prior to launching code.