### PR TITLE
[.NET Profiler] Set required env vars to enable .NET Profiler

### DIFF
--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -175,6 +175,12 @@ setUpDotnetEnv() {
     export CORECLR_PROFILER="{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
     export CORECLR_PROFILER_PATH="${DD_DIR}/Datadog.Trace.ClrProfiler.Native.so"
     export DD_DOTNET_TRACER_HOME="${DD_DIR}"
+    if [[ "${DD_PROFILING_ENABLED:-,,}" == "1" ]]; then
+        echo "Profiler is enabled."
+        export LD_PRELOAD="${DD_DIR}/continuousprofiler/Datadog.Linux.ApiWrapper.x64.so ${LD_PRELOAD}"
+        # Allow the profiler to add this to its tag
+        export WEBSITE_OS="linux"
+    fi
 }
 
 setUpJavaEnv() {


### PR DESCRIPTION
.NET profiler on linux requires the `LD_PRELOAD` set with the wrapping library.

Also adding the `WEBSITE_OS` to avoid having `unknown` for profiler tag.