### PR TITLE
Bump tracer versions to latest.

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -21,7 +21,7 @@ jobs:
           file: ../../Dockerfile
           platforms: linux/amd64
           build-args: |
-            AGENT_VERSION=7.43.0-1
+            AGENT_VERSION=7.50.1
             RELEASE_VERSION=${{ github.ref_name }}
           tags: datadog-aas
           load: true

--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -158,7 +158,7 @@ setUpNodeEnv() {
 setUpDotnetEnv() {
     echo "Setting up Datadog tracing for .NET"
     if [ -z "${DD_DOTNET_TRACER_VERSION}" ]; then
-        DD_DOTNET_TRACER_VERSION=2.40.0
+        DD_DOTNET_TRACER_VERSION=2.44.0
     fi
 
     # Set a tracer directory to avoid issues with unarchiving
@@ -196,7 +196,7 @@ setUpDotnetEnv() {
 setUpJavaEnv() {
     echo "Setting up Datadog tracing for Java"
     if [ -z "${DD_JAVA_TRACER_VERSION}" ]; then
-        DD_JAVA_TRACER_VERSION=1.19.3
+        DD_JAVA_TRACER_VERSION=1.26.1
     fi
 
     echo "Using version ${DD_JAVA_TRACER_VERSION} of the JAVA tracer"
@@ -222,7 +222,7 @@ setUpJavaEnv() {
 setupPHPEnv() {
     echo "Setting up Datadog tracing for PHP"
     if [ -z "${DD_PHP_TRACER_VERSION}" ]; then
-        DD_PHP_TRACER_VERSION=0.90.0
+        DD_PHP_TRACER_VERSION=0.96.0
     fi
 
     DD_PHP_TRACER_URL=https://github.com/DataDog/dd-trace-php/releases/download/${DD_PHP_TRACER_VERSION}/datadog-setup.php
@@ -239,7 +239,7 @@ setupPHPEnv() {
 setUpPyEnv() {
     echo "Setting up Datadog tracing for Python"
     if [ -z "${DD_PYTHON_TRACER_VERSION}" ]; then
-        DD_PYTHON_TRACER_VERSION=1.18.2
+        DD_PYTHON_TRACER_VERSION=2.4.0
     fi
 
     pip install ddtrace


### PR DESCRIPTION
Dotnet: 2.44.0
Java: 1.26.1
PHP: 0.96.0
Python: 2.4.0