### PR TITLE
Fix trace-agent arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ _Note: Currently Java, NODE, .NET, PHP and Python are supported._
 ##### Node, .NET, PHP or Python
 Add the following to the startup command box
 
-      curl -s https://raw.githubusercontent.com/DataDog/datadog-aas-linux/v1.7.0/datadog_wrapper | bash
+      curl -s https://raw.githubusercontent.com/DataDog/datadog-aas-linux/v1.8.0/datadog_wrapper | bash
 
 ![](https://p-qkfgo2.t2.n0.cdn.getcloudapp.com/items/8LuqpR7e/6a9bf63d-5169-49d0-a68a-20e6e3009d47.jpg?v=7704a16bc91a6a57caf8befd84204415)
 

--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -62,7 +62,7 @@ setEnvVars() {
     fi
 
     if [ -z "${DD_AAS_LINUX_VERSION}" ]; then
-        DD_AAS_LINUX_VERSION="v1.7.0"
+        DD_AAS_LINUX_VERSION="v1.8.0"
     fi
 
     if [ -z "${DD_BINARY_DIR}" ]; then
@@ -118,6 +118,9 @@ getBinaries() {
             echo "Removing zip file"
             rm "${FILE}"
 
+            # The trace agent requires a datadog.yaml
+            touch "${DD_BINARY_DIR}/datadog.yaml"
+
         else
             echo "Failed to download the Datadog binary succesfully."
             return
@@ -134,7 +137,7 @@ startBinaries() {
 
     if [ "${DD_TRACE_ENABLED}" = "true" ]; then
         echo "Starting the trace agent"
-        eval "${DD_BINARY_DIR}/process_manager ${BINARY_DIR}/trace-agent &"
+        eval "${DD_BINARY_DIR}/process_manager ${BINARY_DIR}/trace-agent run -c ${DD_BINARY_DIR} &"
     fi
 
     if [ "$DD_CUSTOM_METRICS_ENABLED" = "true" ]; then


### PR DESCRIPTION
The newer version of the trace agent requires additional arguments and a datadog.yaml file. This PR bumps the wrapper version and adds the new arguments.