### PR TITLE
Update process manager and release version

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ _Note: Currently Java, NODE, .NET, PHP and Python are supported._
 ##### Node, .NET, PHP or Python
 Add the following to the startup command box
 
-      curl -s https://raw.githubusercontent.com/DataDog/datadog-aas-linux/v1.8.0/datadog_wrapper | bash
+      curl -s https://raw.githubusercontent.com/DataDog/datadog-aas-linux/v1.8.1/datadog_wrapper | bash
 
 ![](https://p-qkfgo2.t2.n0.cdn.getcloudapp.com/items/8LuqpR7e/6a9bf63d-5169-49d0-a68a-20e6e3009d47.jpg?v=7704a16bc91a6a57caf8befd84204415)
 

--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -62,7 +62,7 @@ setEnvVars() {
     fi
 
     if [ -z "${DD_AAS_LINUX_VERSION}" ]; then
-        DD_AAS_LINUX_VERSION="v1.8.0"
+        DD_AAS_LINUX_VERSION="v1.8.1"
     fi
 
     if [ -z "${DD_BINARY_DIR}" ]; then

--- a/process_manager/src/main.rs
+++ b/process_manager/src/main.rs
@@ -9,10 +9,14 @@ fn main() {
     let dd_arg = command.get_program().to_str().unwrap();
     if dd_arg.ends_with("dogstatsd") {
         command.arg(&dd_command[2]);
+    // trace-agent requires the args: run -c <datadog.yaml location>
+    } else if dd_arg.ends_with("trace-agent") {
+        command.args(&dd_command[2..=4]);
     }
 
     spawn(command);
 }
+
 fn spawn(mut command: Command) {
     if let Ok(mut dd_process) = command.spawn() {
         let status = dd_process.wait().expect("dd_process wasn't running");


### PR DESCRIPTION
The process manager needed to be adjusted to handle the new arguments passed to the trace-agent. This was missed in the last release.