### PR TITLE
Start dogstatsd when only runtime metrics are enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ _Note: Currently Java, NODE, .NET, PHP and Python are supported._
 ##### Node, .NET, PHP or Python
 Add the following to the startup command box
 
-      curl -s https://raw.githubusercontent.com/DataDog/datadog-aas-linux/v1.9.0/datadog_wrapper | bash
+      curl -s https://raw.githubusercontent.com/DataDog/datadog-aas-linux/v.1.10.0/datadog_wrapper | bash
 
 ![](https://p-qkfgo2.t2.n0.cdn.getcloudapp.com/items/8LuqpR7e/6a9bf63d-5169-49d0-a68a-20e6e3009d47.jpg?v=7704a16bc91a6a57caf8befd84204415)
 

--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -65,7 +65,7 @@ setEnvVars() {
     fi
 
     if [ -z "${DD_AAS_LINUX_VERSION}" ]; then
-        DD_AAS_LINUX_VERSION="v1.9.0"
+        DD_AAS_LINUX_VERSION="v.1.10.0"
     fi
 
     if [ -z "${DD_BINARY_DIR}" ]; then

--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -136,7 +136,7 @@ startBinaries() {
         eval "${DD_BINARY_DIR}/process_manager ${BINARY_DIR}/trace-agent run -c ${DD_BINARY_DIR} &"
     fi
 
-    if [ "$DD_CUSTOM_METRICS_ENABLED" = "true" ]; then
+    if [ "$DD_CUSTOM_METRICS_ENABLED" = "true" ] || [ "$DD_RUNTIME_METRICS_ENABLED" = "true" ]; then
         echo "Starting DogStatsD"
         eval "${DD_BINARY_DIR}/process_manager ${BINARY_DIR}/dogstatsd start &"
     fi


### PR DESCRIPTION
This change starts the dogstatsd agent when `DD_RUNTIME_METRICS_ENABLED` is set to true. Previously it was only started when `DD_CUSTOM_METRICS_ENABLED` was set to true. Covers the case where custom metrics are disabled but runtime metrics are enabled.

Motivation is issue https://github.com/DataDog/datadog-aas-linux/issues/9
