### PR TITLE
Create workflow dispatch for self-monitoring updates

### DIFF
--- a/.github/workflows/update_apps.yml
+++ b/.github/workflows/update_apps.yml
@@ -1,9 +1,7 @@
 name: update_self_monitoring_apps
 
 on:
-  release:
-    types: [prereleased]
-
+  workflow_dispatch:
 
 jobs:
   update_apps:


### PR DESCRIPTION
Triggering the update workflow was not working automatically as expected. Using a manual dispatch instead.