### PR TITLE
adding version checking to support node 16 runtimes

### DIFF
--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -152,13 +152,13 @@ startBinaries() {
 }
 
 setUpNodeEnv() {
-    NODE_RUNTIME_VERSION="`node --version`"
+    NODE_RUNTIME_VERSION=$(node --version}
     echo "Found runtime version ${NODE_RUNTIME_VERSION}"
     echo "Setting up Datadog tracing for Node"
     echo "Installing Node tracer"
 
     if [[ "$NODE_RUNTIME_VERSION" =~ ^v16.* ]]; then
-        yarn add "dd-trace@^4.38.1" || return
+        yarn add "dd-trace@4.38.1" || return
     else
         yarn add dd-trace || return
     fi

--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -152,9 +152,16 @@ startBinaries() {
 }
 
 setUpNodeEnv() {
+    NODE_RUNTIME_VERSION="`node --version`"
+    echo "Found runtime version ${NODE_RUNTIME_VERSION}"
     echo "Setting up Datadog tracing for Node"
     echo "Installing Node tracer"
-    yarn add dd-trace || return
+
+    if [[ "$NODE_RUNTIME_VERSION" =~ ^v16.* ]]; then
+        yarn add "dd-trace@^4.38.1" || return
+    else
+        yarn add dd-trace || return
+    fi
 
     ORIG_NODE_OPTIONS=$NODE_OPTIONS
     export NODE_OPTIONS="--require=${DD_DIR}/node_modules/dd-trace/init ${ORIG_NODE_OPTIONS}"

--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -152,7 +152,7 @@ startBinaries() {
 }
 
 setUpNodeEnv() {
-    NODE_RUNTIME_VERSION=${node --version}
+    NODE_RUNTIME_VERSION=$(node --version)
     echo "Found runtime version ${NODE_RUNTIME_VERSION}"
     echo "Setting up Datadog tracing for Node"
     echo "Installing Node tracer"

--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -152,7 +152,7 @@ startBinaries() {
 }
 
 setUpNodeEnv() {
-    NODE_RUNTIME_VERSION=$(node --version}
+    NODE_RUNTIME_VERSION=${node --version}
     echo "Found runtime version ${NODE_RUNTIME_VERSION}"
     echo "Setting up Datadog tracing for Node"
     echo "Installing Node tracer"


### PR DESCRIPTION
This adds a check in the datadog wrapper to see which node version is installed. If version 16 is detected the compatible version of dd-trace is installed. 