### PR TITLE
fix: symbolic link to libresolv.so.2

### DIFF
--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -101,6 +101,7 @@ getRuntimeDependencies() {
         else
             apk add curl
             apk add libc6-compat
+            ln -sfv ld-linux-x86-64.so.2 /lib/libresolv.so.2
         fi
     fi
 }

--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -101,6 +101,7 @@ getRuntimeDependencies() {
         else
             apk add curl
             apk add libc6-compat
+            apk add gcompat
             ln -sfv ld-linux-x86-64.so.2 /lib/libresolv.so.2
         fi
     fi


### PR DESCRIPTION
I have an Azure App Service deployment with the following stack and App Service Plan Sku:
Publishing model: Code
Runtime Stack: Java 8 Tomcat
Operating System: Linux
Instance Count: 1
SKU and size: PremiumV3 (P2v3)

I set the startup command for the App Service as per the documenation:
```
curl -s -L -o $path https://raw.githubusercontent.com/Datadog/datadog-aas-linux/fix/libresolv/datadog_wrapper
az webapp deploy --resource-group $resourceGroupName --name $name --src-path $path --type=startup
```

I get the following error:
2024-06-19T15:30:13.727334949Z DataDog process exit status: 127 has finished
2024-06-19T15:30:13.729224576Z Error loading shared library libresolv.so.2: No such file or directory (needed by /home/datadog/v1.10.6/trace-agent)
2024-06-19T15:30:13.729332077Z Error relocating /home/datadog/v1.10.6/trace-agent: __res_search: symbol not found

I found the following solution that has resolved the issue for my use case:
https://gitlab.alpinelinux.org/alpine/aports/-/issues/14846
```
ln -sfv ld-linux-x86-64.so.2 /lib/libresolv.so.2
```

Any enhancements to make this more robust for other contexts would be appreciated.