### PR TITLE
[SVLS-4872] Improve AAS Linux wrapper install logic

### DIFF
--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -109,7 +109,7 @@ getRuntimeDependencies() {
 
 getBinaries() {
     # Check if we have already installed this version or if we successfully downloaded binaries before
-    if [ ! -d "${DD_BINARY_DIR}" -o -z "$(ls -A "${DD_BINARY_DIR}")" ]; then
+    if [ ! -d "${DD_BINARY_DIR}" -o -f "${DD_BINARY_DIR}"/datadog.yaml ]; then
 
         FILE="datadog-aas-${DD_AAS_LINUX_VERSION}.zip"
 

--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -109,7 +109,7 @@ getRuntimeDependencies() {
 
 getBinaries() {
     #Check if we have already installed this version
-    if [ ! -d "${DD_BINARY_DIR}" ! -a "${DD_BINARIES_URL}"]; then
+    if [ ! -d "${DD_BINARY_DIR}" -a ! "${DD_BINARIES_URL}"]; then
 
         FILE="datadog-aas-${DD_AAS_LINUX_VERSION}.zip"
 

--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -108,8 +108,8 @@ getRuntimeDependencies() {
 }
 
 getBinaries() {
-    #Check if we have already installed this version and if we successfully downloaded binaries from the URL
-    if [ ! -d "${DD_BINARY_DIR}" -a -d "${DD_BINARIES_URL}" ]; then
+    # Check if we have already installed this version and if we successfully downloaded binaries from the URL
+    if [ ! -d "${DD_BINARY_DIR}" -a ! -d "${DD_BINARIES_URL}" ]; then
 
         FILE="datadog-aas-${DD_AAS_LINUX_VERSION}.zip"
 

--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -68,7 +68,7 @@ setEnvVars() {
         DD_AAS_LINUX_VERSION="v1.10.6"
     fi
 
-    if [ -z "${DD_TRACE_LOG_DIRECTORY}"]; then
+    if [ -z "${DD_TRACE_LOG_DIRECTORY}" ]; then
         DD_TRACE_LOG_DIRECTORY="/home/LogFiles/datadog/${DD_AAS_LINUX_VERSION}"
     fi
 
@@ -108,8 +108,8 @@ getRuntimeDependencies() {
 }
 
 getBinaries() {
-    #Check if we have already installed this version
-    if [ ! -d "${DD_BINARY_DIR}" -a ! -d "${DD_BINARIES_URL}"]; then
+    #Check if we have already installed this version and if we successfully downloaded binaries from the URL
+    if [ ! -d "${DD_BINARY_DIR}" -a -d "${DD_BINARIES_URL}" ]; then
 
         FILE="datadog-aas-${DD_AAS_LINUX_VERSION}.zip"
 

--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -108,8 +108,8 @@ getRuntimeDependencies() {
 }
 
 getBinaries() {
-    # Check if we have already installed this version or if we successfully downloaded datadog yaml before
-    if [ ! -d "${DD_BINARY_DIR}" ] || [ -f "${DD_BINARY_DIR}"/datadog.yaml ]; then
+    # Check if we have already installed this version or if we successfully downloaded binaries before
+    if [ ! -d "${DD_BINARY_DIR}" -o -z "$(ls -A "${DD_BINARY_DIR}")" ]; then
 
         FILE="datadog-aas-${DD_AAS_LINUX_VERSION}.zip"
 

--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -108,8 +108,8 @@ getRuntimeDependencies() {
 }
 
 getBinaries() {
-    # Check if we have already installed this version and if we successfully downloaded binaries before
-    if [ ! -d "${DD_BINARY_DIR}" -a ! -d "${DD_AAS_LINUX_VERSION}" ]; then
+    # Check if we have already installed this version or if we successfully downloaded binaries before
+    if [ ! -d "${DD_BINARY_DIR}" ] || [ -z "$(ls -A "${DD_BINARY_DIR}")" ]; then
 
         FILE="datadog-aas-${DD_AAS_LINUX_VERSION}.zip"
 

--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -108,8 +108,8 @@ getRuntimeDependencies() {
 }
 
 getBinaries() {
-    # Check if we have already installed this version and if we successfully downloaded binaries from the URL
-    if [ ! -d "${DD_BINARY_DIR}" -a ! -d "${DD_BINARIES_URL}" ]; then
+    # Check if we have already installed this version and if we successfully downloaded binaries before
+    if [ ! -d "${DD_BINARY_DIR}" -a ! -d "${DD_AAS_LINUX_VERSION}" ]; then
 
         FILE="datadog-aas-${DD_AAS_LINUX_VERSION}.zip"
 

--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -109,7 +109,7 @@ getRuntimeDependencies() {
 
 getBinaries() {
     #Check if we have already installed this version
-    if [ ! -d "${DD_BINARY_DIR}" -a ! "${DD_BINARIES_URL}"]; then
+    if [ ! -d "${DD_BINARY_DIR}" -a ! -d "${DD_BINARIES_URL}"]; then
 
         FILE="datadog-aas-${DD_AAS_LINUX_VERSION}.zip"
 

--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -109,7 +109,7 @@ getRuntimeDependencies() {
 
 getBinaries() {
     # Check if we have already installed this version or if we successfully downloaded binaries before
-    if [ ! -d "${DD_BINARY_DIR}" -o -f "${DD_BINARY_DIR}"/datadog.yaml ]; then
+    if [ ! -d "${DD_BINARY_DIR}" -o -z "$(ls -A "${DD_BINARY_DIR}")" ]; then
 
         FILE="datadog-aas-${DD_AAS_LINUX_VERSION}.zip"
 

--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -109,7 +109,7 @@ getRuntimeDependencies() {
 
 getBinaries() {
     #Check if we have already installed this version
-    if [ ! -d "${DD_BINARY_DIR}" -a -d "${DD_BINARIES_URL}"]; then
+    if [ ! -d "${DD_BINARY_DIR}" ! -a "${DD_BINARIES_URL}"]; then
 
         FILE="datadog-aas-${DD_AAS_LINUX_VERSION}.zip"
 

--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -108,8 +108,8 @@ getRuntimeDependencies() {
 }
 
 getBinaries() {
-    # Check if we have already installed this version or if we successfully downloaded binaries before
-    if [ ! -d "${DD_BINARY_DIR}" ] || [ -z "$(ls -A "${DD_BINARY_DIR}")" ]; then
+    # Check if we have already installed this version or if we successfully downloaded datadog yaml before
+    if [ ! -d "${DD_BINARY_DIR}" ] || [ -f "${DD_BINARY_DIR}"/datadog.yaml ]; then
 
         FILE="datadog-aas-${DD_AAS_LINUX_VERSION}.zip"
 

--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -109,7 +109,7 @@ getRuntimeDependencies() {
 
 getBinaries() {
     #Check if we have already installed this version
-    if [ ! -d "${DD_BINARY_DIR}" ]; then
+    if [ ! -d "${DD_BINARY_DIR}" -a -d "${DD_BINARIES_URL}"]; then
 
         FILE="datadog-aas-${DD_AAS_LINUX_VERSION}.zip"
 


### PR DESCRIPTION
Check if binaries currently exist inside of `DD_BINARY_DIR` if binaries were not properly downloaded or deleted and no longer exist then we reinstall the directory and all files

This was tested inside of my web app [nina-test-app ](https://portal.azure.com/#@devdatadoghq.onmicrosoft.com/resource/subscriptions/1dd25961-a5c7-45bf-a5ba-c1475d365cc7/resourceGroups/nina-serverless/providers/Microsoft.Web/sites/nina-test-app/appServices) by setting the starting command to `curl -s https://raw.githubusercontent.com/DataDog/datadog-aas-linux/nina.rei/SVLS-4872/AAS-Linux-Binaries/datadog_wrapper | bash`

Tested my code by: 
- delete datadog binaries directory inside of ssh
- run startup command and check if  DD_BINARY_DIR doesn't exists 
   - this should reinstall binaries  
- delete datadog binaries inside of ssh and then rerun the command 
- check if both DD_BINARY_DIR and files inside exist
   - this should reinstall the binaries
- rerun and both DD_BINARY_DIR and files inside exist
   - this should reuse the previous binaries 