### PR TITLE
Bump version to v1.10.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ _Note: Currently Java, NODE, .NET, PHP and Python are supported._
 ##### Node, .NET, PHP or Python
 Add the following to the startup command box
 
-      curl -s https://raw.githubusercontent.com/DataDog/datadog-aas-linux/v1.10.6/datadog_wrapper | bash
+      curl -s https://raw.githubusercontent.com/DataDog/datadog-aas-linux/v1.10.7/datadog_wrapper | bash
 
 ![](https://p-qkfgo2.t2.n0.cdn.getcloudapp.com/items/8LuqpR7e/6a9bf63d-5169-49d0-a68a-20e6e3009d47.jpg?v=7704a16bc91a6a57caf8befd84204415)
 

--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -65,7 +65,7 @@ setEnvVars() {
     fi
 
     if [ -z "${DD_AAS_LINUX_VERSION}" ]; then
-        DD_AAS_LINUX_VERSION="v1.10.6"
+        DD_AAS_LINUX_VERSION="v1.10.7"
     fi
 
     if [ -z "${DD_TRACE_LOG_DIRECTORY}" ]; then


### PR DESCRIPTION
Includes [the following changes](https://github.com/DataDog/datadog-aas-linux/compare/v1.10.6...aleksandr.pasechnik/release-candidate-v1.10.7):
- fix for the DataDog binary download
- pinning node tracer versions
- updating pinned tracer versions to the latest available tracers
- new script to update documentation
- Github workflows to update pinned tracer versions