### PR TITLE
[SLES-1884] Bump agent version

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -21,7 +21,7 @@ jobs:
           file: ../../Dockerfile
           platforms: linux/amd64
           build-args: |
-            AGENT_VERSION=7.52.0
+            AGENT_VERSION=7.57.2
             RELEASE_VERSION=${{ github.ref_name }}
           tags: datadog-aas
           load: true


### PR DESCRIPTION
We may need to upgrade our agent version to enable Azure App Services span attributes.