### PR TITLE
[VULN-8308] Give elevated permissions on the job-level for specific workflows

### DIFF
--- a/.github/workflows/dotnet_tracer_update_version.yml
+++ b/.github/workflows/dotnet_tracer_update_version.yml
@@ -7,7 +7,10 @@ on:
 jobs:
   bump_version:
     runs-on: ubuntu-latest
-
+    permissions:
+      pull-requests: write
+      packages: write
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/java_tracer_update_version.yml
+++ b/.github/workflows/java_tracer_update_version.yml
@@ -7,7 +7,10 @@ on:
 jobs:
   bump_version:
     runs-on: ubuntu-latest
-
+    permissions:
+      pull-requests: write
+      packages: write
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/node_tracer_v4_update_version.yml
+++ b/.github/workflows/node_tracer_v4_update_version.yml
@@ -7,7 +7,10 @@ on:
 jobs:
   bump_version:
     runs-on: ubuntu-latest
-
+    permissions:
+      pull-requests: write
+      packages: write
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/node_tracer_v5_update_version.yml
+++ b/.github/workflows/node_tracer_v5_update_version.yml
@@ -7,7 +7,10 @@ on:
 jobs:
   bump_version:
     runs-on: ubuntu-latest
-
+    permissions:
+      pull-requests: write
+      packages: write
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/php_tracer_update_version.yml
+++ b/.github/workflows/php_tracer_update_version.yml
@@ -7,7 +7,10 @@ on:
 jobs:
   bump_version:
     runs-on: ubuntu-latest
-
+    permissions:
+      pull-requests: write
+      packages: write
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/python_tracer_update_version.yml
+++ b/.github/workflows/python_tracer_update_version.yml
@@ -7,7 +7,10 @@ on:
 jobs:
   bump_version:
     runs-on: ubuntu-latest
-
+    permissions:
+      pull-requests: write
+      packages: write
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Previously updated the repo root permissions to default all workflows to read-only due to [these tickets](https://datadoghq.atlassian.net/issues/VULN-8308?filter=23735) and new datadog security policy. I updated the specific workflows that we know need to create write contents from the repo.  Following [this doc](https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/3913581900/GitHub+Workflow+Token+Permissions+GITHUB_TOKEN#:~:text=action/workflow%20level-,Give%20preference%20to%20elevating%20permissions%20on%20the%20job%2Dlevel%20NOT%20the%20whole%20workflow!,-name%3A%20%22Build) to updated the `GITHUB_TOKEN`

we noticed[ this error](https://github.com/DataDog/datadog-aas-linux/actions/runs/11705132061/job/32600803737) in Update Version for the Python Tracer Job