### PR TITLE
chore: [SVLS-5939] disable metadata collection

### DIFF
--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -4,6 +4,7 @@ main() {
     # Required to add the AAS metadata
     export DD_AZURE_APP_SERVICES=1
     export DD_APM_REMOTE_TAGGER=false
+    export DD_ENABLE_METADATA_COLLECTION=false
 
     # Remote Config does not work in AAS. It must be disabled.
     export DD_REMOTE_CONFIGURATION_ENABLED=false


### PR DESCRIPTION
As a followup to removing the `DD_HOSTNAME`, we also probably need to do this for billing purposes.