### PR TITLE
chore: update v5 node tracer version to 5.29.1 and wrapper to v1.10.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ _Note: Currently Java, NODE, .NET, PHP and Python are supported._
 ##### Node, .NET, PHP or Python
 Add the following to the startup command box
 
-      curl -s https://raw.githubusercontent.com/DataDog/datadog-aas-linux/v1.10.11/datadog_wrapper | bash
+      curl -s https://raw.githubusercontent.com/DataDog/datadog-aas-linux/v1.10.12/datadog_wrapper | bash
 
 ![](https://p-qkfgo2.t2.n0.cdn.getcloudapp.com/items/8LuqpR7e/6a9bf63d-5169-49d0-a68a-20e6e3009d47.jpg?v=7704a16bc91a6a57caf8befd84204415)
 

--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -157,7 +157,7 @@ setUpNodeEnv() {
     echo "Setting up Datadog tracing for Node"
     echo "Installing Node tracer"
 
-    local DD_NODE_TRACER_VERSION_4=4.53.0
+    local DD_NODE_TRACER_VERSION_4=4.49.0
 
     local DD_NODE_TRACER_VERSION_5=5.29.1
 

--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -159,7 +159,7 @@ setUpNodeEnv() {
 
     local DD_NODE_TRACER_VERSION_4=4.53.0
 
-    local DD_NODE_TRACER_VERSION_5=5.29.0
+    local DD_NODE_TRACER_VERSION_5=5.29.1
 
     if [[ "$NODE_RUNTIME_VERSION" =~ ^v16.* ]]; then
         yarn add "dd-trace@$DD_NODE_TRACER_VERSION_4" || return

--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -66,7 +66,7 @@ setEnvVars() {
     fi
 
     if [ -z "${DD_AAS_LINUX_VERSION}" ]; then
-        DD_AAS_LINUX_VERSION="v1.10.11"
+        DD_AAS_LINUX_VERSION="v1.10.12"
     fi
 
     if [ -z "${DD_TRACE_LOG_DIRECTORY}" ]; then

--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -157,9 +157,9 @@ setUpNodeEnv() {
     echo "Setting up Datadog tracing for Node"
     echo "Installing Node tracer"
 
-    local DD_NODE_TRACER_VERSION_4=4.49.0
+    local DD_NODE_TRACER_VERSION_4=4.53.0
 
-    local DD_NODE_TRACER_VERSION_5=5.25.0
+    local DD_NODE_TRACER_VERSION_5=5.29.0
 
     if [[ "$NODE_RUNTIME_VERSION" =~ ^v16.* ]]; then
         yarn add "dd-trace@$DD_NODE_TRACER_VERSION_4" || return


### PR DESCRIPTION
A fix was released in the Node tracer that is required to be added to the wrapper.

Also updates the wrapper version.