### PR TITLE
Allow User Installed Tracer to be specified with NODE_PATH

### DIFF
--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -171,7 +171,7 @@ setUpNodeEnv() {
     ORIG_NODE_PATH=$NODE_PATH
 
     export NODE_OPTIONS="--require=dd-trace/init ${ORIG_NODE_OPTIONS}"
-    export NODE_PATH="${ORIG_NODE_PATH};/home/site/wwwroot/node_modules;${DD_DIR}/node_modules"
+    export NODE_PATH="${ORIG_NODE_PATH}:/home/site/wwwroot/node_modules:${DD_DIR}/node_modules"
 
     # confirm updates to NODE_OPTIONS
     node --help >/dev/null || (export NODE_OPTIONS="${ORIG_NODE_OPTIONS}" && export NODE_PATH="${ORIG_NODE_PATH}" && return)

--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -168,10 +168,13 @@ setUpNodeEnv() {
     fi
 
     ORIG_NODE_OPTIONS=$NODE_OPTIONS
-    export NODE_OPTIONS="--require=${DD_DIR}/node_modules/dd-trace/init ${ORIG_NODE_OPTIONS}"
+    ORIG_NODE_PATH=$NODE_PATH
+
+    export NODE_OPTIONS="--require=dd-trace/init ${ORIG_NODE_OPTIONS}"
+    export NODE_PATH="${ORIG_NODE_PATH};/home/site/wwwroot/node_modules;${DD_DIR}/node_modules"
 
     # confirm updates to NODE_OPTIONS
-    node --help >/dev/null || (export NODE_OPTIONS="${ORIG_NODE_OPTIONS}" && return)
+    node --help >/dev/null || (export NODE_OPTIONS="${ORIG_NODE_OPTIONS}" && export NODE_PATH="${ORIG_NODE_PATH}" && return)
 }
 
 setUpDotnetEnv() {


### PR DESCRIPTION
By default the wrapper script installs a pinned version of the Node tracer. If a customer wants to roll back to an older version of the tracer or use a newer version that hasn't been pinned yet, they can add it as a dependency to their project.

In order, Node will check these directories for the tracer:
* Customer specified directory in `NODE_PATH` (if a non standard install)
* `/home/site/wwwroot/node_modules` (where dependencies are added for a standard install)
* `${DD_DIR}/node_modules` (version of the tracer installed as part of the wrapper script)