### PR TITLE
Add ability to select Node tracer version through App Settings

### DIFF
--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -161,10 +161,14 @@ setUpNodeEnv() {
 
     local DD_NODE_TRACER_VERSION_5=5.30.0
 
-    if [[ "$NODE_RUNTIME_VERSION" =~ ^v16.* ]]; then
-        yarn add "dd-trace@$DD_NODE_TRACER_VERSION_4" || return
+    if [ -z "${DD_NODE_TRACER_VERSION}" ]; then
+        if [[ "$NODE_RUNTIME_VERSION" =~ ^v16.* ]]; then
+            yarn add "dd-trace@$DD_NODE_TRACER_VERSION_4" || return
+        else
+            yarn add "dd-trace@$DD_NODE_TRACER_VERSION_5" || return
+        fi
     else
-        yarn add "dd-trace@$DD_NODE_TRACER_VERSION_5" || return
+        yarn add "dd-trace@$DD_NODE_TRACER_VERSION"
     fi
 
     ORIG_NODE_OPTIONS=$NODE_OPTIONS


### PR DESCRIPTION
- Adds `DD_NODE_TRACER_VERSION` for easier testing in Node environments. Setting a version in Application Settings will replace the default version set in the wrapper.