### PR TITLE
fix: handle flaky node tracer installation

### DIFF
--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -152,8 +152,6 @@ startBinaries() {
 }
 
 setUpNodeEnv() {
-    NODE_RUNTIME_VERSION=$(node --version)
-    echo "Found runtime version ${NODE_RUNTIME_VERSION}"
     echo "Setting up Datadog tracing for Node"
 
     if [ "${DD_NODE_TRACER_SKIP_INSTALL}" = "true" ]; then

--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -168,11 +168,21 @@ setUpNodeEnv() {
         npm install dd-trace@${DD_NODE_TRACER_VERSION_TO_INSTALL}
     fi
 
-    ORIG_NODE_OPTIONS=$NODE_OPTIONS
-    export NODE_OPTIONS="--require=${DD_DIR}/node_modules/dd-trace/init ${ORIG_NODE_OPTIONS}"
+    ORIG_NODE_PATH=$NODE_PATH
 
-    # confirm updates to NODE_OPTIONS
-    node --help >/dev/null || (export NODE_OPTIONS="${ORIG_NODE_OPTIONS}" && return)
+    # remove trailing colon if present
+    [[ "${ORIG_NODE_PATH}" == *: ]] && MODIFIED_ORIG_NODE_PATH="${ORIG_NODE_PATH::-1}"
+
+    # use tracer installed as part of application build if available, otherwise use the tracer installed by this script
+    export NODE_PATH="${MODIFIED_ORIG_NODE_PATH}:/home/site/wwwroot/node_modules:${DD_DIR}/node_modules"
+    echo "NODE_PATH updated from ${ORIG_NODE_PATH} to ${NODE_PATH}"
+
+    ORIG_NODE_OPTIONS=$NODE_OPTIONS
+    export NODE_OPTIONS="--require=dd-trace/init ${ORIG_NODE_OPTIONS}"
+    echo "NODE_OPTIONS updated from ${ORIG_NODE_OPTIONS} to ${NODE_OPTIONS}"
+
+    # confirm updates to NODE_OPTIONS and NODE_PATH
+    node --help >/dev/null || (export NODE_OPTIONS="${ORIG_NODE_OPTIONS}" && export NODE_PATH="${ORIG_NODE_PATH}" && return)
 }
 
 setUpDotnetEnv() {

--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -160,9 +160,9 @@ setUpNodeEnv() {
     local DD_NODE_TRACER_VERSION_5=5.48.1
 
     if [ -z "${DD_NODE_TRACER_VERSION}" ]; then
-        yarn add "dd-trace@$DD_NODE_TRACER_VERSION_5"
+        npm install "dd-trace@$DD_NODE_TRACER_VERSION_5"
     else
-        yarn add "dd-trace@$DD_NODE_TRACER_VERSION"
+        npm install "dd-trace@$DD_NODE_TRACER_VERSION"
     fi
 
     ORIG_NODE_OPTIONS=$NODE_OPTIONS

--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -160,7 +160,7 @@ setUpNodeEnv() {
     local DD_NODE_TRACER_VERSION_5=5.48.1
 
     if [ -z "${DD_NODE_TRACER_VERSION}" ]; then
-        yarn add "dd-trace@$DD_NODE_TRACER_VERSION_5" || return
+        yarn add "dd-trace@$DD_NODE_TRACER_VERSION_5"
     else
         yarn add "dd-trace@$DD_NODE_TRACER_VERSION"
     fi

--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -162,6 +162,10 @@ setUpNodeEnv() {
         # use provided tracer version in DD_NODE_TRACER_VERSION if available, otherwise use the default version
         local DD_NODE_TRACER_VERSION_TO_INSTALL="${DD_NODE_TRACER_VERSION:-$DD_DEFAULT_NODE_TRACER_VERSION_5}"
 
+        # create package.json if it does not already exist, otherwise the npm install command will fail
+        echo "Initializing npm package"
+        npm init -y
+
         echo "Installing Datadog Node tracer ${DD_NODE_TRACER_VERSION_TO_INSTALL}"
         npm install dd-trace@${DD_NODE_TRACER_VERSION_TO_INSTALL}
     fi

--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -173,11 +173,11 @@ setUpNodeEnv() {
 
     # use tracer installed as part of application build if available, otherwise use the tracer installed by this script
     export NODE_PATH="${MODIFIED_ORIG_NODE_PATH}:/home/site/wwwroot/node_modules:${DD_DIR}/node_modules"
-    echo "NODE_PATH updated from ${ORIG_NODE_PATH} to ${NODE_PATH}"
+    echo "NODE_PATH updated from '${ORIG_NODE_PATH}' to '${NODE_PATH}'"
 
     ORIG_NODE_OPTIONS=$NODE_OPTIONS
     export NODE_OPTIONS="--require=dd-trace/init ${ORIG_NODE_OPTIONS}"
-    echo "NODE_OPTIONS updated from ${ORIG_NODE_OPTIONS} to ${NODE_OPTIONS}"
+    echo "NODE_OPTIONS updated from '${ORIG_NODE_OPTIONS}' to '${NODE_OPTIONS}'"
 
     # confirm updates to NODE_OPTIONS and NODE_PATH
     node --help >/dev/null || (export NODE_OPTIONS="${ORIG_NODE_OPTIONS}" && export NODE_PATH="${ORIG_NODE_PATH}" && return)

--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -155,14 +155,17 @@ setUpNodeEnv() {
     NODE_RUNTIME_VERSION=$(node --version)
     echo "Found runtime version ${NODE_RUNTIME_VERSION}"
     echo "Setting up Datadog tracing for Node"
-    echo "Installing Node tracer"
 
-    local DD_NODE_TRACER_VERSION_5=5.48.1
-
-    if [ -z "${DD_NODE_TRACER_VERSION}" ]; then
-        npm install "dd-trace@$DD_NODE_TRACER_VERSION_5"
+    if [ "${DD_NODE_TRACER_SKIP_INSTALL}" = "true" ]; then
+        echo "DD_NODE_TRACER_SKIP_INSTALL set to true, skipping Datadog Node tracer installation"
     else
-        npm install "dd-trace@$DD_NODE_TRACER_VERSION"
+        local DD_DEFAULT_NODE_TRACER_VERSION_5=5.48.1
+
+        # use provided tracer version in DD_NODE_TRACER_VERSION if available, otherwise use the default version
+        local DD_NODE_TRACER_VERSION_TO_INSTALL="${DD_NODE_TRACER_VERSION:-$DD_DEFAULT_NODE_TRACER_VERSION_5}"
+
+        echo "Installing Datadog Node tracer ${DD_NODE_TRACER_VERSION_TO_INSTALL}"
+        npm install dd-trace@${DD_NODE_TRACER_VERSION_TO_INSTALL}
     fi
 
     ORIG_NODE_OPTIONS=$NODE_OPTIONS


### PR DESCRIPTION
### What does this PR do?

- Remove `return` statement on failed node tracer installation
- Use npm instead of yarn for node tracer installation
- add `DD_NODE_TRACER_SKIP_INSTALL` environment variable to optionally skip node tracer installation
- configure `NODE_PATH` to use node tracer installed with application if available

### Motivation

https://datadoghq.atlassian.net/browse/SVLS-6671

Errors like the one below can occasionally occur while installing the Node tracer. When this happens and the `DD_NODE_TRACER_VERSION` environment variable is not configured, the script short circuits and `NODE_OPTIONS` is not set, resulting in the tracer not being initialized on application startup.

However when the `DD_NODE_TRACER_VERSION` environment variable is configured, even if the tracer installation fails the script does not short circuit and `NODE_OPTIONS` ends up using the tracer that was previously installed (assuming there was a successful installation at one point).

https://github.com/DataDog/datadog-aas-linux/blob/ee8dd44739656b4dddac221abe51a158f2823f17/datadog_wrapper#L162-L169

```
Error: ENOENT: no such file or directory, copyfile '/usr/local/share/.cache/yarn/v6/npm-dd-trace-5.30.0-b81cf5f1e20822bee55bcb0dfe475578cea59faf-integrity/node_modules/dd-trace/ext/priority.js' -> '/home/datadog/node_modules/dd-trace/ext/priority.js'
```

### Additional Notes

- Per @rochdev, `npm` should be used for the Node tracer installation since it's more stable than `yarn`
- By configuring the `NODE_PATH` to include `/home/site/wwwroot/node_modules` we allow customers to use the tracer installed with their application. In this use case they can also use the `DD_NODE_TRACER_SKIP_INSTALL` environment variable to skip the Node tracer install from the script to speed up application startup

### Describe how to test/QA your changes

Deploy to Azure App Service web app using the wrapper script from this branch as the startup command.

```
curl -s https://raw.githubusercontent.com/DataDog/datadog-aas-linux/refs/heads/duncan-harvey/fix-flaky-node-tracer-install/datadog_wrapper | bash
```

- No `DD_NODE_TRACER_VERSION` configured -> default Node tracer initialized
- `DD_NODE_TRACER_VERSION` configured -> specified Node tracer initialized
- Node tracer installed in application -> application Node tracer initialized
- `DD_NODE_TRACER_SKIP_INSTALL` -> script skips Node tracer installation
- Node tracer installation from script on fresh install -> script successfully installs Node tracer