### PR TITLE
Revert "Bump peter-evans/create-pull-request from 7.0.5 to 7.0.8 (#117)"

### DIFF
--- a/.github/workflows/dotnet_tracer_update_version.yml
+++ b/.github/workflows/dotnet_tracer_update_version.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Create Pull Request
         id: pr
-        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e  # v7.0.8
+        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f  # v7.0.5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: "dotnet-tracer-version-bump"

--- a/.github/workflows/java_tracer_update_version.yml
+++ b/.github/workflows/java_tracer_update_version.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Create Pull Request
         id: pr
-        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e  # v7.0.8
+        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f  # v7.0.5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: "java-tracer-version-bump"

--- a/.github/workflows/node_tracer_v5_update_version.yml
+++ b/.github/workflows/node_tracer_v5_update_version.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Create Pull Request
         id: pr
-        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e  # v7.0.8
+        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f  # v7.0.5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: "node-tracer-v5-version-bump"

--- a/.github/workflows/php_tracer_update_version.yml
+++ b/.github/workflows/php_tracer_update_version.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Create Pull Request
         id: pr
-        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e  # v7.0.8
+        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f  # v7.0.5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: "php-tracer-version-bump"

--- a/.github/workflows/python_tracer_update_version.yml
+++ b/.github/workflows/python_tracer_update_version.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Create Pull Request
         id: pr
-        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e  # v7.0.8
+        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f  # v7.0.5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: "python-tracer-version-bump"


### PR DESCRIPTION
This reverts commit ee8dd44739656b4dddac221abe51a158f2823f17.

Actions failing after bumping `peter-evans/create-pull-request` version.

https://github.com/DataDog/datadog-aas-linux/actions/runs/14620190264
<img width="1180" alt="Screenshot 2025-04-23 at 3 28 37 PM" src="https://github.com/user-attachments/assets/f7efb490-ea61-4e2a-a49d-bcd9194d79de" />
