### PR TITLE
fix: use correct environment variable for node tracer update workflow

### DIFF
--- a/.github/workflows/datadog_wrapper_tracer_update.py
+++ b/.github/workflows/datadog_wrapper_tracer_update.py
@@ -20,15 +20,9 @@ configs = {
         repo_name="dd-trace-dotnet",
         major_version_equal_to=None,
     ),
-    "node_v4": Config(
-        name="Node.js Tracer v4",
-        version_variable="local DD_NODE_TRACER_VERSION_4",
-        repo_name="dd-trace-js",
-        major_version_equal_to=4,
-    ),
     "node_v5": Config(
         name="Node.js Tracer v5",
-        version_variable="local DD_NODE_TRACER_VERSION_5",
+        version_variable="local DD_DEFAULT_NODE_TRACER_VERSION_5",
         repo_name="dd-trace-js",
         major_version_equal_to=5,
     ),


### PR DESCRIPTION
Following the changes in https://github.com/DataDog/datadog-aas-linux/pull/118 the incorrect environment variable was checked in the workflow to update the Node Tracer. As a result the workflow failed to complete and no PRs were generated to update the tracer version.