### PR TITLE
[SINT-3854] update dd-octo-sts policy name

### DIFF
--- a/.github/workflows/node_tracer_v5_update_version.yml
+++ b/.github/workflows/node_tracer_v5_update_version.yml
@@ -20,7 +20,7 @@ jobs:
         id: octo-sts
         with:
           scope: DataDog/datadog-aas-linux
-          policy: self.tracer-v5-update.create-pr
+          policy: self.tracer-update.create-pr
 
       - name: Modify build-packages
         id: version


### PR DESCRIPTION
Follow-up of https://github.com/DataDog/datadog-aas-linux/pull/139
Fixes this error: https://github.com/DataDog/datadog-aas-linux/actions/runs/16806773418