### PR TITLE
chore: prepare for v1.14.0 release

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -25,7 +25,7 @@ jobs:
           file: ../../Dockerfile
           platforms: linux/amd64
           build-args: |
-            AGENT_VERSION=7.70.1
+            AGENT_VERSION=7.72.4
             RELEASE_VERSION=${{ github.ref_name }}
           tags: datadog-aas
           load: true

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ _Note: Currently Java, NODE, .NET, PHP and Python are supported._
 ##### Node, .NET, PHP or Python
 Add the following to the startup command box
 
-      curl -s https://raw.githubusercontent.com/DataDog/datadog-aas-linux/v1.13.0/datadog_wrapper | bash
+      curl -s https://raw.githubusercontent.com/DataDog/datadog-aas-linux/v1.14.0/datadog_wrapper | bash
 
 ![](https://p-qkfgo2.t2.n0.cdn.getcloudapp.com/items/8LuqpR7e/6a9bf63d-5169-49d0-a68a-20e6e3009d47.jpg?v=7704a16bc91a6a57caf8befd84204415)
 

--- a/datadog_wrapper
+++ b/datadog_wrapper
@@ -66,7 +66,7 @@ setEnvVars() {
     fi
 
     if [ -z "${DD_AAS_LINUX_VERSION}" ]; then
-        DD_AAS_LINUX_VERSION="v1.13.0"
+        DD_AAS_LINUX_VERSION="v1.14.0"
     fi
 
     if [ -z "${DD_TRACE_LOG_DIRECTORY}" ]; then


### PR DESCRIPTION
- Bump agent version to 7.72.4
- Bump DD_AAS_LINUX_VERSION to 1.14.0