### PR TITLE
fix: run apt-get update and apt-get install in same layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,7 @@ ARG AGENT_VERSION
 ARG RELEASE_VERSION
 # make the AGENT_VERSION arg mandatory
 RUN : "${AGENT_VERSION:?AGENT_VERSION needs to be provided}"
-RUN apt-get update
-RUN apt-get install -y curl binutils zip
+RUN apt-get update && apt-get install -y curl binutils zip
 RUN mkdir ${RELEASE_VERSION}
 COPY --from=rust-binary /target/x86_64-unknown-linux-musl/release/process_manager ${RELEASE_VERSION}/
 


### PR DESCRIPTION
Fixes below error:

https://github.com/DataDog/datadog-aas-linux/actions/runs/19831429086/job/56818223616
```
 > [agent  4/16] RUN apt-get install -y curl binutils zip:
3.121 Fetched 3951 kB in 1s (3156 kB/s)
3.121 E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/b/binutils/binutils-common_2.42-4ubuntu2.7_amd64.deb  404  Not Found [IP: 91.189.91.82 80]
3.121 E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/b/binutils/libsframe1_2.42-4ubuntu2.7_amd64.deb  404  Not Found [IP: 91.189.91.82 80]
3.121 E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/b/binutils/libbinutils_2.42-4ubuntu2.7_amd64.deb  404  Not Found [IP: 91.189.91.82 80]
3.121 E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/b/binutils/libctf-nobfd0_2.42-4ubuntu2.7_amd64.deb  404  Not Found [IP: 91.189.91.82 80]
3.121 E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/b/binutils/libctf0_2.42-4ubuntu2.7_amd64.deb  404  Not Found [IP: 91.189.91.82 80]
3.121 E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/b/binutils/libgprofng0_2.42-4ubuntu2.7_amd64.deb  404  Not Found [IP: 91.189.91.82 80]
3.121 E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/b/binutils/binutils-x86-64-linux-gnu_2.42-4ubuntu2.7_amd64.deb  404  Not Found [IP: 91.189.91.82 80]
3.121 E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/b/binutils/binutils_2.42-4ubuntu2.7_amd64.deb  404  Not Found [IP: 91.189.91.82 80]
3.121 E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```